### PR TITLE
Revert "Bump mixin-deep from 1.3.1 to 1.3.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3841,9 +3841,9 @@
             "dev": true
         },
         "mixin-deep": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
                 "for-in": "^1.0.2",


### PR DESCRIPTION
Reverts kindredFP/kindredfp.github.io#3